### PR TITLE
Fonttextures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OS = $(shell uname)
 ifeq ($(OS), Linux)
-	FLAGS += `pkg-config --cflags --libs sdl2` -lSDL2_mixer -pthread -lSDL2_ttf -I/usr/local/include/
+	FLAGS += -lSDL2 -lSDL2_mixer -pthread -lSDL2_ttf -I/usr/local/include/ -g
 else
 ifeq ($(OS), Darwin)
 	FLAGS += -F/Library/Frameworks -framework SDL2 -framework SDL2_mixer -framework SDL2_ttf -L/usr/local/lib -I/usr/local/include/ -g

--- a/text.cpp
+++ b/text.cpp
@@ -1,20 +1,26 @@
 #include "text.h"
 
+TextObject::~TextObject(){
+	delete this->text; // clean up the text
+}
+
 void TextObject::display(int x, int y)
 {
-	drawSDLTexture(text, x, y, size.x, size.y);
+	drawTexture(text, x, y);
 }
 
 void TextObject::displayCentered(int x, int y)
 {
-	drawSDLTexture(text, x-(size.x/2), y-(size.y/2), size.x, size.y);
+	drawTexture(text, x-(text->getWidth()/2), y-(text->getHeight()/2));
 }
 
 void TextObject::setText(string _text, AXFont* font)
 {
+	if(text){
+		delete text;
+	}
 	AXColour fill = AXColour(0,0,0,0);
 	text = font->bakeTexture(_text, fill);
-	size = font->getStringSize(_text);
 	rawString = _text;
 }
         

--- a/text.cpp
+++ b/text.cpp
@@ -6,12 +6,14 @@ TextObject::~TextObject(){
 
 void TextObject::display(int x, int y)
 {
-	drawTexture(text, x, y);
+	if(text) drawTexture(text, x, y);
+	else AXLog::error("Invalid text texture being drawn.");
 }
 
 void TextObject::displayCentered(int x, int y)
 {
-	drawTexture(text, x-(text->getWidth()/2), y-(text->getHeight()/2));
+	if(text) drawTexture(text, x-(text->getWidth()/2), y-(text->getHeight()/2));
+	else AXLog::error("Invalid text texture being drawn.");
 }
 
 void TextObject::setText(string _text, AXFont* font)

--- a/text.h
+++ b/text.h
@@ -7,9 +7,9 @@ class TextObject
 {
 	private:
 		string rawString;
-		SDL_Texture* text;
-		AXVector2D size;
+		AXTexture* text;
 	public:
+		~TextObject();
 		void display(int x, int y);
 		void displayCentered(int x, int y);
 		void setText(string _text, AXFont* font);


### PR DESCRIPTION
Updated to the new way Axilya generates fonts using the `bakeText` method in `AXFont`, also identified an error in the game over text.

The update loop will see there are less than 25 moves played and play the final move. When the draw method sees there are 25 moves played later that frame it will attempt to draw the `gameOver` text, but this hasn't been set by the update loop until next frame. Consider only checking the 25 moves played in the update loop